### PR TITLE
fix: Avoid creating new documents when indentation is wrong

### DIFF
--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -229,7 +229,7 @@ func (e *syntaxError) As(dest any) bool {
 		return true
 	}
 
-	return xerrors.As(e, dest)
+	return false
 }
 
 type TypeError struct {

--- a/validate_test.go
+++ b/validate_test.go
@@ -116,11 +116,11 @@ name: myDocument
 roles:
   name: myRole
   permissions:
-	- hello
-	- how
-	- are
-	- you
-	`,
+    - hello
+    - how
+    - are
+    - you
+ `,
 			ExpectedErr: `[4:7] mapping was used where sequence is expected
    1 | ---
    2 | name: myDocument
@@ -128,9 +128,9 @@ roles:
 >  4 |   name: myRole
              ^
    5 |   permissions:
-   6 | 	- hello
-   7 | 	- how
-   8 | `,
+   6 |     - hello
+   7 |     - how
+   8 |     `,
 			Instance: &struct {
 				Name  string `yaml:"name"`
 				Roles []struct {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -212,11 +212,13 @@ b:
 	}
 }
 
-type ObjectMap map[string]*Object
-type ObjectDecl struct {
-	Name    string `yaml:"-"`
-	*Object `yaml:",inline,anchor"`
-}
+type (
+	ObjectMap  map[string]*Object
+	ObjectDecl struct {
+		Name    string `yaml:"-"`
+		*Object `yaml:",inline,anchor"`
+	}
+)
 
 func (m ObjectMap) MarshalYAML() (interface{}, error) {
 	newMap := map[string]*ObjectDecl{}
@@ -740,7 +742,6 @@ hoge:
 			t.Fatalf("expected:%s but got %s", expected, actual)
 		}
 	})
-
 }
 
 func Test_CommentToMapOption(t *testing.T) {
@@ -1246,7 +1247,6 @@ a: 1 # line
 				t.Fatalf("expected:\n%s\ngot:\n%s\n", expect, got)
 			}
 		})
-
 	}
 }
 
@@ -1275,7 +1275,7 @@ func TestRegisterCustomUnmarshaler(t *testing.T) {
 		return nil
 	})
 	var v T
-	if err := yaml.Unmarshal([]byte(`"foo: "bar"`), &v); err != nil {
+	if err := yaml.Unmarshal([]byte(`"foo": "bar"`), &v); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(v.Foo, []byte("override")) {


### PR DESCRIPTION
Avoid creating a new document for wrongly indented values. For example the following creates three documents when it should really complain about bad indentation at `bar`.

```yaml
a: b
c: > 
  foo
 bar
d: e
```

Also fixes an `errors.As` bug and test cases that had wrong indentation.